### PR TITLE
Fixed issue where automatic detection of jade files didn't work.

### DIFF
--- a/Jade.sublime-build
+++ b/Jade.sublime-build
@@ -1,6 +1,6 @@
 {
 	"cmd": ["jade", "$file", "--pretty"],
-	"selector": "source.jade",
+	"selector": ["source.jade"],
 	"osx": {"path": "/usr/local/bin:$PATH"},
 	"windows": {"shell": "true"}
 }


### PR DESCRIPTION
Even with the "automatic" option checked in the build options, jade files wouldn't build with ctrl + B unless manually selected. This fixed the issue.
